### PR TITLE
Permit override of $(prefix) and other vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ STRIPLIB     = $(STRIP) --strip-unneeded
 
 SOVERSION    = 1
 
-prefix = /usr/local
-exec_prefix = $(prefix)
-bindir = $(exec_prefix)/bin
-includedir = $(prefix)/include
-libdir = $(prefix)/lib
-mandir = $(prefix)/man
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+includedir ?= $(prefix)/include
+libdir ?= $(prefix)/lib
+mandir ?= $(prefix)/man
 
 CFLAGS	+= -O3 -Wall -pthread -fpic
 #CFLAGS	+= -O0 -g -Wall -pthread -fpic


### PR DESCRIPTION
I've been putting together a debian package for lg (for eventual inclusion in ubuntu and hopefully raspbian); not quite finished yet, but the current status can be found in https://launchpad.net/~waveform/+archive/ubuntu/lg/+packages. Obviously with the package I wanted to target the /usr hierarchy rather than /usr/local and wondered if you'd mind making some of the Makefile vars conditional to make them a bit easier to tweak from the packaging rules?

Incidentally, many thanks for writing this! Once the packaging tasks are done I'll be looking at incorporating an lg driver into gpiozero (though there's a ton of other stuff I need to look at there too, like all the Pi4/400/CM4 stuff!).