### PR TITLE
Fix building the Python extension from other dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,10 @@ clean:
 	rm -f *.o *.i *.s *~ $(ALL) *.so.$(SOVERSION)
 
 ifeq ($(DESTDIR),)
+  PYBUILDARGS =
   PYINSTALLARGS =
 else
+  PYBUILDARGS = --include-dirs=$(DESTDIR)$(includedir) --library-dirs=$(DESTDIR)$(libdir)
   PYINSTALLARGS = --root=$(DESTDIR)
 endif
 
@@ -135,8 +137,18 @@ endif
 	@if which python2; then cd PY_RGPIO && python2 setup.py -q install $(PYINSTALLARGS) || echo "*** install of Python2 rgpio.py failed ***"; fi
 	@if which python3; then cd PY_RGPIO && python3 setup.py -q install $(PYINSTALLARGS) || echo "*** install of Python3 rgpio.py failed ***"; fi
 	@if which swig; then cd PY_LGPIO && swig -python lgpio.i || echo "*** need swig package to install lgpio.py ***"; fi
-	@if which swig python2; then cd PY_LGPIO && python2 setup.py -q install $(PYINSTALLARGS) || echo "*** install of Python2 lgpio.py failed ***"; fi
-	@if which swig python3; then cd PY_LGPIO && python3 setup.py -q install $(PYINSTALLARGS) || echo "*** install of Python3 lgpio.py failed ***"; fi
+	@if which swig python2; then \
+		cd PY_LGPIO && \
+		python2 setup.py build_ext $(PYBUILDARGS) && \
+		python2 setup.py -q install $(PYINSTALLARGS) || \
+		echo "*** install of Python2 lgpio.py failed ***"; \
+	fi
+	@if which swig python3; then \
+		cd PY_LGPIO && \
+		python3 setup.py build_ext $(PYBUILDARGS) && \
+		python3 setup.py -q install $(PYINSTALLARGS) || \
+		echo "*** install of Python3 lgpio.py failed ***"; \
+	fi
 
 uninstall:
 	rm -f $(DESTDIR)$(includedir)/lgpio.h


### PR DESCRIPTION
Another patch derived from the packaging work. I've checked that this doesn't affect "normal" installations, but it's certainly necessary for building the Python extensions when the installation destination isn't included in the include and lib paths (which is probably rather abnormal for the make; make install procedure, but a typical scenario when building for packaging).