### PR TITLE
Fix some minor groff warnings

### DIFF
--- a/lgpio.3
+++ b/lgpio.3
@@ -1,7 +1,7 @@
 
-." Process this file with
-." groff -man -Tascii lg.3
-."
+.\" Process this file with
+.\" groff -man -Tascii lg.3
+.\"
 .TH lgpio 3 2020-2021 Linux "lg archive"
 .SH NAME
 lgpio - A C library to manipulate a local SBC's GPIO.
@@ -13,7 +13,7 @@ lgpio - A C library to manipulate a local SBC's GPIO.
 
 gcc -Wall -o prog prog.c -llgpio
 
- ./prog
+\&./prog
 .SH DESCRIPTION
 
 
@@ -81,7 +81,7 @@ command to build and run the executable.
 .EX
 gcc -Wall -o prog prog.c -llgpio
 .br
-./prog
+\&./prog
 .br
 
 .EE

--- a/rgpio.3
+++ b/rgpio.3
@@ -1,7 +1,7 @@
 
-." Process this file with
-." groff -man -Tascii lgd_if.3
-."
+.\" Process this file with
+.\" groff -man -Tascii lgd_if.3
+.\"
 .TH rgpio 3 2020-2021 Linux "lg archive"
 .SH NAME
 rgpio - A C library to manipulate a remote SBC's GPIO.
@@ -13,7 +13,7 @@ rgpio - A C library to manipulate a remote SBC's GPIO.
 
 gcc -Wall -o prog prog.c -lrgpio
 
- ./prog
+\&./prog
 .SH DESCRIPTION
 
 
@@ -108,7 +108,7 @@ rgpiod&
 .br
 
 .br
- ./prog
+\&./prog
 .br
 
 .EE

--- a/rgpiod.1
+++ b/rgpiod.1
@@ -1,7 +1,7 @@
 
-." Process this file with
-." groff -man -Tascii lgd.1
-."
+.\" Process this file with
+.\" groff -man -Tascii lgd.1
+.\"
 .TH rgpiod 1 2020-2021 Linux "lg archive"
 .SH NAME
 rgpiod - a daemon to allow remote access to a SBC's GPIO.

--- a/rgs.1
+++ b/rgs.1
@@ -1,7 +1,7 @@
 
-." Process this file with
-." groff -man -Tascii foo.1
-."
+.\" Process this file with
+.\" groff -man -Tascii foo.1
+.\"
 .TH rgs 1 2020-2021 Linux "lg archive"
 .SH NAME
 rgs - a shell command to manipulate a remote SBC's GPIO.
@@ -1548,8 +1548,7 @@ Multiple waves may be queued in this way.
 
 .br
 
-.IP "\fBGBUSY h g k\fP - GPIO or group tx busy
-.br"
+.IP "\fBGBUSY h g k\fP - GPIO or group tx busy"
 .IP "" 4
 
 .br


### PR DESCRIPTION
Another patch derived from the packaging work; just fixes some warnings that lintian threw out when building the man-pages. Unfortunately, I'm nowhere near an expert in roff so I'm not 100% sure that these patches would be compatible with non-GNU implementations, and I've not yet had the time to spin up a BSD card to test them - I'll try and get to that next week.