### PR TITLE
Use uint16_t for gpio in lgGpioReport_t

### DIFF
--- a/lgpio.h
+++ b/lgpio.h
@@ -380,7 +380,7 @@ typedef struct
 {
    uint64_t timestamp; /* alert time in nanoseconds*/
    uint8_t chip; /* gpiochip device number */
-   uint8_t gpio; /* offset into gpio device */
+   uint16_t gpio; /* offset into gpio device */
    uint8_t level; /* 0=low, 1=high, 2=watchdog */
    uint8_t flags; /* none defined, ignore report if non-zero */
 } lgGpioReport_t;


### PR DESCRIPTION
This solves the problem I saw in #30, where chips with GPIO numbers > 255 would overflow the previously used `uint8_t` type.

Works as expected in C on my Orange Pi. Not sure if Python would be affected in any way?