### PR TITLE
Makefile cleanup for cross compiling ease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 #
-# Set CROSS_PREFIX to prepend to all compiler tools at once for easier
+# Set CROSS_COMPILE to prepend to all compiler tools at once for easier
 # cross-compilation.
-CROSS_PREFIX ?=
-CC           ?= $(CROSS_PREFIX)gcc
-AR           ?= $(CROSS_PREFIX)ar
-RANLIB       ?= $(CROSS_PREFIX)ranlib
-SIZE         ?= $(CROSS_PREFIX)size
-STRIP        ?= $(CROSS_PREFIX)strip
+CROSS_COMPILE ?=
+CC           ?= $(CROSS_COMPILE)gcc
+AR           ?= $(CROSS_COMPILE)ar
+RANLIB       ?= $(CROSS_COMPILE)ranlib
+SIZE         ?= $(CROSS_COMPILE)size
+STRIP        ?= $(CROSS_COMPILE)strip
 SHLIB        ?= $(CC) -shared
 STRIPLIB     ?= $(STRIP) --strip-unneeded
 PYTHON       ?= python3


### PR DESCRIPTION
In general, for cross compiling, the `CROSS_COMPILE` variable name is used rather than `CROSS_PREFIX`.  Additionally, to ease integration with tools like OpenEmbedded's bitbake or other distro building systems, allow for each of the compiler names to be overridden easily by the environment rather than needing to edit the Makefile.