### PR TITLE
define and use type-safe callbacks

### DIFF
--- a/lgGpio.c
+++ b/lgGpio.c
@@ -56,7 +56,7 @@ For more information, please refer to <http://unlicense.org/>
 
 void xWrite(lgChipObj_p chip, int gpio, int value);
 
-callbk_t lgGpioSamplesFunc = NULL;
+callbk_alert_t lgGpioSamplesFunc = NULL;
 void *lgGpioSamplesUserdata = NULL;
 
 static inline void xSetBit(uint64_t *b, int n)

--- a/lgGpio.h
+++ b/lgGpio.h
@@ -39,7 +39,7 @@ typedef struct lgLineInf_s
    int      fd;
    int      debounce_us;
    int      watchdog_us;
-   callbk_t alertFunc;
+   callbk_alert_t alertFunc;
    void     *userdata;
    uint32_t offset;
    uint32_t *offsets_p;
@@ -63,7 +63,7 @@ void xWrite(lgChipObj_p chip, int gpio, int value);
 void xGroupWrite(
    lgChipObj_p chip, int gpio, uint64_t groupBits, uint64_t groupMask);
 
-extern callbk_t lgGpioSamplesFunc;
+extern callbk_alert_t lgGpioSamplesFunc;
 extern void *lgGpioSamplesUserdata;
 
 #endif

--- a/lgI2C.c
+++ b/lgI2C.c
@@ -874,7 +874,7 @@ int lgI2cOpen(int i2cDev, int i2cAddr, int i2cFlags)
    LG_DBG(LG_DEBUG_ALLOC, "alloc i2c: *%p", (void*)i2c);
 
    handle = lgHdlAlloc(
-      LG_HDL_TYPE_I2C, sizeof(lgI2cObj_t), (void **)&i2c, _lgI2cClose);
+      LG_HDL_TYPE_I2C, sizeof(lgI2cObj_t), (void **)&i2c, (void*)_lgI2cClose);
 
    if (handle < 0)
    {

--- a/lgNotify.c
+++ b/lgNotify.c
@@ -123,7 +123,7 @@ int lgNotifyOpenWithSize(int bufSize)
    LG_DBG(LG_DEBUG_INTERNAL, "bufSize=%d", bufSize);
 
    handle = lgHdlAlloc(
-      LG_HDL_TYPE_NOTIFY, sizeof(lgNotify_t), (void**)&h, _notifyClose);
+      LG_HDL_TYPE_NOTIFY, sizeof(lgNotify_t), (void**)&h, (void*)_notifyClose);
 
    if (handle < 0) {return LG_NO_MEMORY;}
 
@@ -178,7 +178,7 @@ int lgNotifyOpenInBand(int fd)
    LG_DBG(LG_DEBUG_TRACE, "fd=%d", fd);
 
    handle = lgHdlAlloc(
-      LG_HDL_TYPE_NOTIFY, sizeof(lgNotify_t), (void**)&h, _notifyClose);
+      LG_HDL_TYPE_NOTIFY, sizeof(lgNotify_t), (void**)&h, (void*)_notifyClose);
 
    if (handle < 0) {return LG_NO_MEMORY;}
 

--- a/lgSPI.c
+++ b/lgSPI.c
@@ -115,7 +115,7 @@ int lgSpiOpen(
    }
 
    handle = lgHdlAlloc(
-      LG_HDL_TYPE_SPI, sizeof(lgSpiObj_t), (void **)&spi, _lgSpiClose);
+      LG_HDL_TYPE_SPI, sizeof(lgSpiObj_t), (void **)&spi, (void*)_lgSpiClose);
 
    if (handle < 0)
    {

--- a/lgSerial.c
+++ b/lgSerial.c
@@ -95,7 +95,7 @@ int lgSerialOpen(const char *serDev, int serBaud, int serFlags)
    }
 
    handle = lgHdlAlloc(LG_HDL_TYPE_SERIAL, sizeof(lgSerialObj_t),
-               (void**)&ser, _lgSerialClose);
+               (void**)&ser, (void*)_lgSerialClose);
 
    if (handle < 0)
    {

--- a/lgpio.h
+++ b/lgpio.h
@@ -374,7 +374,7 @@ typedef struct
    int      max_emits;
 } lgNotify_t;
 
-typedef void (*callbk_t) ();
+typedef void (*callbk_t) (void *cb);
 
 typedef struct
 {
@@ -419,6 +419,8 @@ typedef struct
 typedef void (*lgGpioAlertsFunc_t)  (int           num_alerts,
                                     lgGpioAlert_p alerts,
                                     void          *userdata);
+
+typedef void (*callbk_alert_t) (int i, struct lgGpioAlert_s *data, void *cb);
 
 typedef void *(lgThreadFunc_t) (void *);
 


### PR DESCRIPTION
- fixes #36
fixes build errors with c23 and gcc-15

```
    error: too many arguments to function 'h->destructor'; expected 0, have 1
    error: passing argument 4 of 'lgHdlAlloc' from incompatible pointer type
      [-Wincompatible-pointer-types]
    note: expected 'callbk_t' {aka 'void (*)(void)'} but argument is of type 'void (*)(struct <anonymous> *)'
    error: too many arguments to function 'lgGpioSamplesFunc'; expected 0, have 3
    error: assignment to 'callbk_t' {aka 'void (*)(void)'} from incompatible pointer type 'lgGpioAlertsFunc_t' {aka 'void (*)(int,  struct lgGpioAlert_s *, void *)'}
    note: 'callbk_t' declared here
      377 | typedef void (*callbk_t) ();
```